### PR TITLE
Add notice that `hashbrown` removed these functions for not helping LLVM consistently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This document contains all changes to the crate since version 0.4.3
 
+## 0.4.7
+
+- Add notice to README that these functions were removed from `hashbrown` for not helping LLVM consistently. Context: https://github.com/rust-lang/hashbrown/issues/482.
+
 ## 0.4.6
 
 - Lower the `rust-version` to 1.38.0 by using Rust edition 2015.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "branch_hints"
-version = "0.4.6"
+version = "0.4.7"
 edition = "2015"
 authors = ["Johanna Sörngård (jsorngard@gmail.com)"]
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -17,10 +17,13 @@ if likely(condition) {
 and they should be optimized away by the compiler.
 
 ## Credit
-The functions are taken directly from the [hashbrown](https://crates.io/crates/hashbrown) crate and this crate simply exposes them, all credit belongs to the hashbrown authors.
+The functions are taken directly from the [`hashbrown`](https://crates.io/crates/hashbrown) crate and this crate simply exposes them, all credit belongs to the hashbrown authors.
 
 ## Note
 This is a very minimal crate. If you want more comprehensive functionality, take a look at the [likely_stable](https://crates.io/crates/likely_stable) crate.
+
+`hashbrown`'s implementation of these functions [has been removed](https://github.com/rust-lang/hashbrown/commit/d677fd42df6978522045a9561242588ef970ed0c) with the motivation that they do not help LLVM consistently.
+Verify for yourself with benchmarks if these functions do anything for you.
 
 <br>
 


### PR DESCRIPTION
Context: https://github.com/rust-lang/hashbrown/issues/482.